### PR TITLE
build.sh Image Name Resolution 해결

### DIFF
--- a/keras/build.sh
+++ b/keras/build.sh
@@ -111,9 +111,9 @@ done
 
 IMAGE_TAG=""
 if [ -z $REGISTRY ]; then
-    IMAGE_TAG="${REGISTRY}/${USERNAME}/${MODEL_NAME}:${TAG}"
-else
     IMAGE_TAG="${USERNAME}/${MODEL_NAME}:${TAG}"
+else
+    IMAGE_TAG="${REGISTRY}/${USERNAME}/${MODEL_NAME}:${TAG}"
 fi
 
 echo "===============================parsed options===============================" >&1


### PR DESCRIPTION
# build.sh Image Tag Resolution 해결


## Tasks

- [x] 조건문 조건으로 인한 image name leading slash 제거


## Discussion

## Jira

- SO1S-446